### PR TITLE
Backend access control

### DIFF
--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       WORDPRESS_ACTIVATE_THEME: "gloggi-theme"   # theme folder relative to /wp-content/themes/
       WORDPRESS_DB_PASSWORD: "xBkLnzRvNWB6Zd56"
       WORDPRESS_SITE_TITLE: "WORDPRESS_SITE_TITLE"
-      WORDPRESS_SITE_USER: "al"
+      WORDPRESS_SITE_USER: "admin"
       WORDPRESS_SITE_PASSWORD: "gloggi"
     env_file:
         - ./.env

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -203,6 +203,25 @@ function gloggi_custom_post_type_gruppe( $wpptd ) {
     'items_list_navigation' => 'Gruppen-Liste Navigation',
     'filter_items_list' => 'Gruppen-Liste filtern',
   );
+  $capabilities = array(
+	// Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+	'edit_post' => 'edit_gruppe',
+	'read_post' => 'read_gruppe',
+	'delete_post' => 'delete_gruppe',
+	// Primitive capabilities (which can be granted directly to a role)
+	'create_posts' => 'create_gruppen',
+	'publish_posts' => 'publish_gruppen',
+	'read' => 'read_gruppen',
+	'read_private_posts' => 'read_private_gruppen',
+	'edit_posts' => 'edit_gruppen',
+	'edit_private_posts' => 'edit_private_gruppen',
+	'edit_published_posts' => 'edit_published_gruppen',
+	'edit_others_posts' => 'edit_others_gruppen',
+	'delete_posts' => 'delete_gruppen',
+	'delete_private_posts' => 'delete_private_gruppen',
+	'delete_published_posts' => 'delete_published_gruppen',
+	'delete_others_posts' => 'delete_others_gruppen',
+  );
   $wpptd->add_components( array(
     'gloggi_gruppen' => array(
       'label' => __( 'Gruppen', 'gloggi' ),
@@ -211,7 +230,7 @@ function gloggi_custom_post_type_gruppe( $wpptd ) {
       'post_types' => array(
         'gruppe' => array(
           'labels' => $labels,
-          'supports' => array( 'title', 'thumbnail', 'page-attributes', ),
+          'supports' => array( 'title', 'thumbnail', 'page-attributes', 'author' ),
           'hierarchical' => true,
           /* Permalinks entfernen */
           'public' => false,
@@ -230,6 +249,8 @@ function gloggi_custom_post_type_gruppe( $wpptd ) {
             'meta-stufe' => array( 'sortable' => true ),
             'meta-geschlecht' => array( 'sortable' => true ),
           ),
+          'capabilities' => $capabilities,
+          'map_meta_cap' => true,
           'metaboxes' => array(
             'gruppeninfos' => array(
               'title' => __( 'Gruppeninformationen', 'gloggi' ),
@@ -820,9 +841,12 @@ function gloggi_add_plugin_capabilities() {
 
     $al_caps = array( 'create_users', 'list_users', 'edit_users', 'promote_users', 'delete_users',
 		'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
+		'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
 		'update_plugins', 'update_themes', 'update_core',
 	);
-    $leiter_caps = array( 'read', 'upload_files' );
+    $leiter_caps = array( 'read', 'upload_files',
+		'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
+    );
 
     $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );
 

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -372,6 +372,25 @@ function gloggi_custom_post_type_anlass( $wpptd ) {
     'items_list_navigation' => 'Anlass-Liste Navigation',
     'filter_items_list' => 'Anlass-Liste filtern',
   );
+  $capabilities = array(
+  // Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+  'edit_post' => 'edit_anlass',
+  'read_post' => 'read_anlass',
+  'delete_post' => 'delete_anlass',
+  // Primitive capabilities (which can be granted directly to a role)
+  'create_posts' => 'create_anlaesse',
+  'publish_posts' => 'publish_anlaesse',
+  'read' => 'read_anlaesse',
+  'read_private_posts' => 'read_private_anlaesse',
+  'edit_posts' => 'edit_anlaesse',
+  'edit_private_posts' => 'edit_private_anlaesse',
+  'edit_published_posts' => 'edit_published_anlaesse',
+  'edit_others_posts' => 'edit_others_anlaesse',
+  'delete_posts' => 'delete_anlaesse',
+  'delete_private_posts' => 'delete_private_anlaesse',
+  'delete_published_posts' => 'delete_published_anlaesse',
+  'delete_others_posts' => 'delete_others_anlaesse',
+  );
   $wpptd->add_components( array(
     'gloggi_anlaesse' => array(
       'label' => __( 'Anl&auml;sse', 'gloggi' ),
@@ -400,6 +419,8 @@ function gloggi_custom_post_type_anlass( $wpptd ) {
             'meta-endzeit' => array( 'sortable' => true ),
             'meta-endort' => array( 'sortable' => true ),
           ),
+          'capabilities' => $capabilities,
+          'map_meta_cap' => true,
           'metaboxes' => array(
             'anlassinfos' => array(
               'title' => __( 'Anlass-Informationen', 'gloggi' ),
@@ -848,10 +869,13 @@ function gloggi_add_plugin_capabilities() {
   $al_caps = array( 'create_users', 'list_users', 'edit_users', 'promote_users', 'delete_users',
     'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
     'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
+    'read_private_anlaesse', 'edit_private_anlaesse', 'edit_others_anlaesse', 'delete_private_anlaesse', 'delete_others_anlaesse',
     'update_plugins', 'update_themes', 'update_core',
   );
   $leiter_caps = array( 'read', 'upload_files', 'level_1',
+    // Keine Rechte auf Stufen
     'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
+    'create_anlaesse', 'publish_anlaesse', 'read_anlaesse', 'edit_anlaesse', 'edit_published_anlaesse', 'delete_anlaesse', 'delete_published_anlaesse',
   );
 
   $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -11,9 +11,9 @@
 // Automatische Updates fuer das Plugin
 require 'plugin-update-checker/plugin-update-checker.php';
 $myUpdateChecker = Puc_v4_Factory::buildUpdateChecker(
-	'http://wp-updates.gloggi.ch/gloggi-plugin.json',
-	__FILE__,
-	'gloggi-abteilungshomepages-plugin'
+  'http://wp-updates.gloggi.ch/gloggi-plugin.json',
+  __FILE__,
+  'gloggi-abteilungshomepages-plugin'
 );
 add_filter( 'auto_update_plugin', '__return_true' );
 
@@ -66,23 +66,23 @@ function gloggi_custom_post_type_stufe( $wpptd ) {
     'filter_items_list' => 'Stufen-Liste filtern',
   );
   $capabilities = array(
-	// Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
-	'edit_post' => 'edit_stufe',
-	'read_post' => 'read_stufe',
-	'delete_post' => 'delete_stufe',
-	// Primitive capabilities (which can be granted directly to a role)
-	'create_posts' => 'create_stufen',
-	'publish_posts' => 'publish_stufen',
-	'read' => 'read_stufen',
-	'read_private_posts' => 'read_private_stufen',
-	'edit_posts' => 'edit_stufen',
-	'edit_private_posts' => 'edit_private_stufen',
-	'edit_published_posts' => 'edit_published_stufen',
-	'edit_others_posts' => 'edit_others_stufen',
-	'delete_posts' => 'delete_stufen',
-	'delete_private_posts' => 'delete_private_stufen',
-	'delete_published_posts' => 'delete_published_stufen',
-	'delete_others_posts' => 'delete_others_stufen',
+  // Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+  'edit_post' => 'edit_stufe',
+  'read_post' => 'read_stufe',
+  'delete_post' => 'delete_stufe',
+  // Primitive capabilities (which can be granted directly to a role)
+  'create_posts' => 'create_stufen',
+  'publish_posts' => 'publish_stufen',
+  'read' => 'read_stufen',
+  'read_private_posts' => 'read_private_stufen',
+  'edit_posts' => 'edit_stufen',
+  'edit_private_posts' => 'edit_private_stufen',
+  'edit_published_posts' => 'edit_published_stufen',
+  'edit_others_posts' => 'edit_others_stufen',
+  'delete_posts' => 'delete_stufen',
+  'delete_private_posts' => 'delete_private_stufen',
+  'delete_published_posts' => 'delete_published_stufen',
+  'delete_others_posts' => 'delete_others_stufen',
   );
   $wpptd->add_components( array(
     'gloggi_stufen' => array(
@@ -204,23 +204,23 @@ function gloggi_custom_post_type_gruppe( $wpptd ) {
     'filter_items_list' => 'Gruppen-Liste filtern',
   );
   $capabilities = array(
-	// Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
-	'edit_post' => 'edit_gruppe',
-	'read_post' => 'read_gruppe',
-	'delete_post' => 'delete_gruppe',
-	// Primitive capabilities (which can be granted directly to a role)
-	'create_posts' => 'create_gruppen',
-	'publish_posts' => 'publish_gruppen',
-	'read' => 'read_gruppen',
-	'read_private_posts' => 'read_private_gruppen',
-	'edit_posts' => 'edit_gruppen',
-	'edit_private_posts' => 'edit_private_gruppen',
-	'edit_published_posts' => 'edit_published_gruppen',
-	'edit_others_posts' => 'edit_others_gruppen',
-	'delete_posts' => 'delete_gruppen',
-	'delete_private_posts' => 'delete_private_gruppen',
-	'delete_published_posts' => 'delete_published_gruppen',
-	'delete_others_posts' => 'delete_others_gruppen',
+  // Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+  'edit_post' => 'edit_gruppe',
+  'read_post' => 'read_gruppe',
+  'delete_post' => 'delete_gruppe',
+  // Primitive capabilities (which can be granted directly to a role)
+  'create_posts' => 'create_gruppen',
+  'publish_posts' => 'publish_gruppen',
+  'read' => 'read_gruppen',
+  'read_private_posts' => 'read_private_gruppen',
+  'edit_posts' => 'edit_gruppen',
+  'edit_private_posts' => 'edit_private_gruppen',
+  'edit_published_posts' => 'edit_published_gruppen',
+  'edit_others_posts' => 'edit_others_gruppen',
+  'delete_posts' => 'delete_gruppen',
+  'delete_private_posts' => 'delete_private_gruppen',
+  'delete_published_posts' => 'delete_published_gruppen',
+  'delete_others_posts' => 'delete_others_gruppen',
   );
   $wpptd->add_components( array(
     'gloggi_gruppen' => array(
@@ -805,53 +805,53 @@ add_action( 'wpptd', 'gloggi_custom_page_type' );
 
 /* Unsere custom roles */
 function gloggi_create_roles( $role_slugs ) {
-	$result = array();
-	foreach( $role_slugs as $role_slug => $name ) {
-		$result[$role_slug] = get_role( $role_slug );
-		if( !$result[$role_slug] ) {
-			add_role( $role_slug, $name, array() );
-			$result[$role_slug] = get_role( $role_slug );
-		}
-	}
-	return result;
+  $result = array();
+  foreach( $role_slugs as $role_slug => $name ) {
+    $result[$role_slug] = get_role( $role_slug );
+    if( !$result[$role_slug] ) {
+      add_role( $role_slug, $name, array() );
+      $result[$role_slug] = get_role( $role_slug );
+    }
+  }
+  return result;
 }
 function gloggi_set_capabilities( $role, $capabilities ) {
-	$all_caps = array( 'create_sites', 'delete_sites', 'manage_network', 'manage_sites', 'manage_network_users', 'manage_network_plugins', 'manage_network_themes', 'manage_network_options', 'upgrade_network', 'setup_network', 'activate_plugins', 'delete_others_pages', 'delete_others_posts', 'delete_pages', 'delete_posts', 'delete_private_pages', 'delete_private_posts', 'delete_published_pages', 'delete_published_posts', 'edit_dashboard', 'edit_others_pages', 'edit_others_posts', 'edit_pages', 'edit_posts', 'edit_private_pages', 'edit_private_posts', 'edit_published_pages', 'edit_published_posts', 'edit_theme_options', 'export', 'import', 'list_users', 'manage_categories', 'manage_links', 'manage_options', 'moderate_comments', 'promote_users', 'publish_pages', 'publish_posts', 'read_private_pages', 'read_private_posts', 'read', 'remove_users', 'switch_themes', 'upload_files', 'customize', 'delete_site', 'update_core', 'update_plugins', 'update_themes', 'install_plugins', 'install_themes', 'upload_plugins', 'upload_themes', 'delete_themes', 'delete_plugins', 'edit_plugins', 'edit_themes', 'edit_files', 'edit_users', 'create_users', 'delete_users', 'unfiltered_html' );
-	$role_obj = get_role( $role );
-	$cap_array = array();
-	foreach( $all_caps as $cap ) {
-		$cap_array[$cap] = false;
-	}
-	foreach( $capabilities as $cap ) {
-		$cap_array[$cap] = true;
-	}
-	foreach( $cap_array as $cap=>$allow ) {
-		if( $allow ) {
-			$role_obj->add_cap( $cap );
-		} else {
-			$role_obj->remove_cap( $cap );
-		}
-	}
+  $all_caps = array( 'create_sites', 'delete_sites', 'manage_network', 'manage_sites', 'manage_network_users', 'manage_network_plugins', 'manage_network_themes', 'manage_network_options', 'upgrade_network', 'setup_network', 'activate_plugins', 'delete_others_pages', 'delete_others_posts', 'delete_pages', 'delete_posts', 'delete_private_pages', 'delete_private_posts', 'delete_published_pages', 'delete_published_posts', 'edit_dashboard', 'edit_others_pages', 'edit_others_posts', 'edit_pages', 'edit_posts', 'edit_private_pages', 'edit_private_posts', 'edit_published_pages', 'edit_published_posts', 'edit_theme_options', 'export', 'import', 'list_users', 'manage_categories', 'manage_links', 'manage_options', 'moderate_comments', 'promote_users', 'publish_pages', 'publish_posts', 'read_private_pages', 'read_private_posts', 'read', 'remove_users', 'switch_themes', 'upload_files', 'customize', 'delete_site', 'update_core', 'update_plugins', 'update_themes', 'install_plugins', 'install_themes', 'upload_plugins', 'upload_themes', 'delete_themes', 'delete_plugins', 'edit_plugins', 'edit_themes', 'edit_files', 'edit_users', 'create_users', 'delete_users', 'unfiltered_html' );
+  $role_obj = get_role( $role );
+  $cap_array = array();
+  foreach( $all_caps as $cap ) {
+    $cap_array[$cap] = false;
+  }
+  foreach( $capabilities as $cap ) {
+    $cap_array[$cap] = true;
+  }
+  foreach( $cap_array as $cap=>$allow ) {
+    if( $allow ) {
+      $role_obj->add_cap( $cap );
+    } else {
+      $role_obj->remove_cap( $cap );
+    }
+  }
 }
 function gloggi_add_capabilities( $role, $capabilities ) {
   $role_obj = get_role( $role );
-	foreach( $capabilities as $cap ) {
+  foreach( $capabilities as $cap ) {
     $role_obj->add_cap( $cap );
-	}
+  }
 }
 function gloggi_add_plugin_capabilities() {
-	remove_role( 'subscriber' );
-	remove_role( 'contributor' );
-	remove_role( 'author' );
-	remove_role( 'editor' );
+  remove_role( 'subscriber' );
+  remove_role( 'contributor' );
+  remove_role( 'author' );
+  remove_role( 'editor' );
 
   $al_caps = array( 'create_users', 'list_users', 'edit_users', 'promote_users', 'delete_users',
-	  'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
-		'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
-		'update_plugins', 'update_themes', 'update_core',
-	);
+    'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
+    'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
+    'update_plugins', 'update_themes', 'update_core',
+  );
   $leiter_caps = array( 'read', 'upload_files', 'level_1',
-		'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
+    'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
   );
 
   $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -833,27 +833,47 @@ function gloggi_set_capabilities( $role, $capabilities ) {
 		}
 	}
 }
+function gloggi_add_capabilities( $role, $capabilities ) {
+  $role_obj = get_role( $role );
+	foreach( $capabilities as $cap ) {
+    $role_obj->add_cap( $cap );
+	}
+}
 function gloggi_add_plugin_capabilities() {
 	remove_role( 'subscriber' );
 	remove_role( 'contributor' );
 	remove_role( 'author' );
 	remove_role( 'editor' );
 
-    $al_caps = array( 'create_users', 'list_users', 'edit_users', 'promote_users', 'delete_users',
-		'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
+  $al_caps = array( 'create_users', 'list_users', 'edit_users', 'promote_users', 'delete_users',
+	  'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
 		'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
 		'update_plugins', 'update_themes', 'update_core',
 	);
-    $leiter_caps = array( 'read', 'upload_files',
+  $leiter_caps = array( 'read', 'upload_files', 'level_1',
 		'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
-    );
+  );
 
-    $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );
+  $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );
 
-    gloggi_set_capabilities( 'al', array_merge( $al_caps, $leiter_caps ) );
-    gloggi_set_capabilities( 'leiter', array_merge( $leiter_caps ) );
+  gloggi_add_capabilities( 'administrator', array_merge( $al_caps, $leiter_caps ) );
+  gloggi_set_capabilities( 'al', array_merge( $al_caps, $leiter_caps ) );
+  gloggi_set_capabilities( 'leiter', array_merge( $leiter_caps ) );
 }
 add_action( 'admin_init', 'gloggi_add_plugin_capabilities' );
+
+
+/* Erlaube alle users als "Autor" (Besitzer) für eine Gruppe, nicht nur "authors" mit dem veralteten access level 1 oder höher. */
+function gloggi_allow_all_authors( $query_args ) {
+  if ( function_exists( get_current_screen ) ) {
+    $screen = get_current_screen();
+      if( $screen->post_type == 'gruppe' && $screen->parent_base == 'edit' ) {
+        $query_args['who'] = '';
+      }
+  }
+  return $query_args;
+}
+add_filter( 'wp_dropdown_users_args', 'gloggi_allow_all_authors' );
 
 
 function endswith($string, $test) {

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -914,6 +914,7 @@ function gloggi_add_plugin_capabilities() {
     'read_private_anlaesse', 'edit_private_anlaesse', 'edit_others_anlaesse', 'delete_private_anlaesse', 'delete_others_anlaesse',
     'create_kontakte', 'publish_kontakte', 'read_kontakte', 'read_private_kontakte', 'edit_kontakte', 'edit_private_kontakte', 'edit_published_kontakte', 'edit_others_kontakte', 'delete_kontakte', 'delete_private_kontakte', 'delete_published_kontakte', 'delete_others_kontakte',
     'create_specialevents', 'publish_specialevents', 'read_specialevents', 'read_private_specialevents', 'edit_specialevents', 'edit_private_specialevents', 'edit_published_specialevents', 'edit_others_specialevents', 'delete_specialevents', 'delete_private_specialevents', 'delete_published_specialevents', 'delete_others_specialevents',
+    'create_pages', 'publish_pages', 'read_pages', 'read_private_pages', 'edit_pages', 'edit_private_pages', 'edit_published_pages', 'edit_others_pages', 'delete_pages', 'delete_private_pages', 'delete_published_pages', 'delete_others_pages',
     'update_plugins', 'update_themes', 'update_core',
   );
   $leiter_caps = array( 'read', 'upload_files', 'level_1',
@@ -922,6 +923,7 @@ function gloggi_add_plugin_capabilities() {
     'create_anlaesse', 'publish_anlaesse', 'read_anlaesse', 'edit_anlaesse', 'edit_published_anlaesse', 'delete_anlaesse', 'delete_published_anlaesse',
     // Keine Rechte auf Kontakten
     // Keine Rechte auf Special Events
+    // Keine Rechte auf Pages
   );
 
   $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -633,6 +633,25 @@ function gloggi_custom_post_type_specialevent( $wpptd ) {
     'items_list_navigation' => 'Special-Event-Liste Navigation',
     'filter_items_list' => 'Special-Event-Liste filtern',
   );
+  $capabilities = array(
+  // Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+  'edit_post' => 'edit_specialevent',
+  'read_post' => 'read_specialevent',
+  'delete_post' => 'delete_specialevent',
+  // Primitive capabilities (which can be granted directly to a role)
+  'create_posts' => 'create_specialevents',
+  'publish_posts' => 'publish_specialevents',
+  'read' => 'read_specialevents',
+  'read_private_posts' => 'read_private_specialevents',
+  'edit_posts' => 'edit_specialevents',
+  'edit_private_posts' => 'edit_private_specialevents',
+  'edit_published_posts' => 'edit_published_specialevents',
+  'edit_others_posts' => 'edit_others_specialevents',
+  'delete_posts' => 'delete_specialevents',
+  'delete_private_posts' => 'delete_private_specialevents',
+  'delete_published_posts' => 'delete_published_specialevents',
+  'delete_others_posts' => 'delete_others_specialevents',
+  );
   $wpptd->add_components( array(
     'gloggi_specialevent' => array(
       'label' => __( 'Special Events', 'gloggi' ),
@@ -657,6 +676,8 @@ function gloggi_custom_post_type_specialevent( $wpptd ) {
             'date' => false,
             'meta-email' => array( 'sortable' => true ),
           ),
+          'capabilities' => $capabilities,
+          'map_meta_cap' => true,
           'metaboxes' => array(
             'specialevent' => array(
               'title' => __( 'Special-Event-Informationen', 'gloggi' ),
@@ -892,6 +913,7 @@ function gloggi_add_plugin_capabilities() {
     'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
     'read_private_anlaesse', 'edit_private_anlaesse', 'edit_others_anlaesse', 'delete_private_anlaesse', 'delete_others_anlaesse',
     'create_kontakte', 'publish_kontakte', 'read_kontakte', 'read_private_kontakte', 'edit_kontakte', 'edit_private_kontakte', 'edit_published_kontakte', 'edit_others_kontakte', 'delete_kontakte', 'delete_private_kontakte', 'delete_published_kontakte', 'delete_others_kontakte',
+    'create_specialevents', 'publish_specialevents', 'read_specialevents', 'read_private_specialevents', 'edit_specialevents', 'edit_private_specialevents', 'edit_published_specialevents', 'edit_others_specialevents', 'delete_specialevents', 'delete_private_specialevents', 'delete_published_specialevents', 'delete_others_specialevents',
     'update_plugins', 'update_themes', 'update_core',
   );
   $leiter_caps = array( 'read', 'upload_files', 'level_1',
@@ -899,6 +921,7 @@ function gloggi_add_plugin_capabilities() {
     'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
     'create_anlaesse', 'publish_anlaesse', 'read_anlaesse', 'edit_anlaesse', 'edit_published_anlaesse', 'delete_anlaesse', 'delete_published_anlaesse',
     // Keine Rechte auf Kontakten
+    // Keine Rechte auf Special Events
   );
 
   $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );

--- a/wordpress/gloggi-plugin/gloggi.php
+++ b/wordpress/gloggi-plugin/gloggi.php
@@ -534,6 +534,25 @@ function gloggi_custom_post_type_kontakt( $wpptd ) {
     'items_list_navigation' => 'Kontakt-Liste Navigation',
     'filter_items_list' => 'Kontakt-Liste filtern',
   );
+  $capabilities = array(
+  // Meta-capabilities (which are granted automatically to roles based on context and the primitive capabilities of the role)
+  'edit_post' => 'edit_kontakt',
+  'read_post' => 'read_kontakt',
+  'delete_post' => 'delete_kontakt',
+  // Primitive capabilities (which can be granted directly to a role)
+  'create_posts' => 'create_kontakte',
+  'publish_posts' => 'publish_kontakte',
+  'read' => 'read_kontakte',
+  'read_private_posts' => 'read_private_kontakte',
+  'edit_posts' => 'edit_kontakte',
+  'edit_private_posts' => 'edit_private_kontakte',
+  'edit_published_posts' => 'edit_published_kontakte',
+  'edit_others_posts' => 'edit_others_kontakte',
+  'delete_posts' => 'delete_kontakte',
+  'delete_private_posts' => 'delete_private_kontakte',
+  'delete_published_posts' => 'delete_published_kontakte',
+  'delete_others_posts' => 'delete_others_kontakte',
+  );
   $wpptd->add_components( array(
     'gloggi_kontakt' => array(
       'label' => __( 'Kontakte', 'gloggi' ),
@@ -558,6 +577,8 @@ function gloggi_custom_post_type_kontakt( $wpptd ) {
             'date' => false,
             'meta-email' => array( 'sortable' => true ),
           ),
+          'capabilities' => $capabilities,
+          'map_meta_cap' => true,
           'metaboxes' => array(
             'kontaktinfos' => array(
               'title' => __( 'Kontakt-Informationen', 'gloggi' ),
@@ -870,12 +891,14 @@ function gloggi_add_plugin_capabilities() {
     'create_stufen', 'publish_stufen', 'read_stufen', 'read_private_stufen', 'edit_stufen', 'edit_private_stufen', 'edit_published_stufen', 'edit_others_stufen', 'delete_stufen', 'delete_private_stufen', 'delete_published_stufen', 'delete_others_stufen',
     'publish_gruppen', 'read_private_gruppen', 'edit_private_gruppen', 'edit_others_gruppen', 'delete_gruppen', 'delete_private_gruppen', 'delete_published_gruppen', 'delete_others_gruppen',
     'read_private_anlaesse', 'edit_private_anlaesse', 'edit_others_anlaesse', 'delete_private_anlaesse', 'delete_others_anlaesse',
+    'create_kontakte', 'publish_kontakte', 'read_kontakte', 'read_private_kontakte', 'edit_kontakte', 'edit_private_kontakte', 'edit_published_kontakte', 'edit_others_kontakte', 'delete_kontakte', 'delete_private_kontakte', 'delete_published_kontakte', 'delete_others_kontakte',
     'update_plugins', 'update_themes', 'update_core',
   );
   $leiter_caps = array( 'read', 'upload_files', 'level_1',
     // Keine Rechte auf Stufen
     'create_gruppen', 'read_gruppen', 'edit_gruppen', 'edit_published_gruppen',
     'create_anlaesse', 'publish_anlaesse', 'read_anlaesse', 'edit_anlaesse', 'edit_published_anlaesse', 'delete_anlaesse', 'delete_published_anlaesse',
+    // Keine Rechte auf Kontakten
   );
 
   $roles = gloggi_create_roles( array( 'administrator' => __( 'Administrator' ), 'al' => __( 'Abteilungsleiter' ), 'leiter' => __( 'Leiter' ) ) );


### PR DESCRIPTION
Removes all existing roles except administrator, and adds new roles.

- **al**: Member of the Abteilungsleitung, with full access to all custom data types.
- **leiter**: Leader of a group, with access to his groups (assigned via the author field) and his anlaesse.
- **administrator**: Webmaster & WordPress debug, full access to everything