### PR TITLE
Add dynamic drop shadow to banner logo

### DIFF
--- a/wordpress/gloggi-theme/header-large.php
+++ b/wordpress/gloggi-theme/header-large.php
@@ -4,7 +4,8 @@
 <div class="header-large">
     <div class="header__image-large"></div>
     <div class="header__banner-large">
-        <img class="header__logo-large" src="<?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilungslogo' ); ?>" alt="">
+        <svg xmlns="http://www.w3.org/2000/svg"><defs><filter id="shadow"><feDropShadow stdDeviation="4"/></filter></defs></svg>
+        <img class="header__logo-large" src="<?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilungslogo' ); ?>" alt="" style="filter:url(#shadow)"/>
         <h1 class="header__title"><?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilung'); ?></h1>
     </div>
 </div>

--- a/wordpress/gloggi-theme/header.php
+++ b/wordpress/gloggi-theme/header.php
@@ -4,7 +4,8 @@
 <div class="header">
     <div class="header__image"></div>
     <div class="header__banner">
-        <img class="header__logo-large" src="<?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilungslogo' ); ?>" alt="">
+        <svg xmlns="http://www.w3.org/2000/svg"><defs><filter id="shadow"><feDropShadow stdDeviation="4"/></filter></defs></svg>
+        <img class="header__logo-large" src="<?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilungslogo' ); ?>" alt="" style="filter:url(#shadow)"/>
         <h1 class="header__title"><?php echo wpod_get_option( 'gloggi_einstellungen', 'abteilung'); ?></h1>
     </div>
     <h1 class="header__heading"><?php echo get_the_title( $post ); ?></h1>


### PR DESCRIPTION
Adds a drop shadow to the banner logo in both banner variants. Works in all browsers: https://caniuse.com/#feat=svg-filters
Tested in Firefox and Chromium with non-rectangular logos and with both .svg and .png image formats.